### PR TITLE
♻️ 선택적으로 process indicator 노출하기

### DIFF
--- a/backend/src/chat-rooms/chat-room.gateway.ts
+++ b/backend/src/chat-rooms/chat-room.gateway.ts
@@ -63,13 +63,18 @@ export class ChatRoomGateway
     ]
       ? 2
       : 1;
+
     console.log(
       `연결: ${chatRoomId}에 현재 접속자: ${
         this.roomState[chatRoomId.toString()]
       }`,
     );
 
-    this.server.emit(chatRoomId.toString(), { full: true });
+    if (this.roomState[chatRoomId.toString()] === 2) {
+      this.server.emit(chatRoomId.toString(), {
+        full: true,
+      });
+    }
   }
 
   handleDisconnect(@ConnectedSocket() socket: Socket) {

--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -14,6 +14,8 @@ import LocationInit from './routers/LocationInit';
 import Post from './routers/Post';
 import ProductChatRooms from './routers/ProductChatRooms';
 import Error404 from './routers/404';
+import { Suspense } from 'react';
+import ChatRoomDetailSkeleton from './components/common/Loading/Skeleton/ChatRommDetailSkeleton';
 
 function Router() {
   // TODO: 채팅 컴포넌트 이름 명확하게 수정하기 e.g 채팅목록은 chatRooms, 채팅방은 chatRoom
@@ -34,7 +36,14 @@ function Router() {
       {/* 나의 채팅 목록  */}
       <Route path={ROUTE.CHAT} element={<ChatRoom />} />
       {/* 채팅방 1개 - 실제 채팅을 하는곳 */}
-      <Route path={`${ROUTE.CHAT}/:chatRoomId`} element={<Chat />} />
+      <Route
+        path={`${ROUTE.CHAT}/:chatRoomId`}
+        element={
+          <Suspense fallback={<ChatRoomDetailSkeleton />}>
+            <Chat />
+          </Suspense>
+        }
+      />
       {/* 내가 판매하는 해당 상품의 채팅 목록  */}
       <Route path={'/products/:productId/chat-rooms'} element={<ProductChatRooms />} />
 

--- a/frontend/src/components/Chatting/ChatRoomList.tsx
+++ b/frontend/src/components/Chatting/ChatRoomList.tsx
@@ -1,0 +1,130 @@
+import Header from 'src/components/common/Header/Header';
+import Image from 'src/components/common/Image/Image';
+import withAuth from 'src/hocs/withAuth';
+import { useChatRooms } from 'src/queries/chatRoom';
+import styled from 'styled-components';
+import timeForToday from 'src/utils/ago';
+import BottomNavigation from 'src/components/common/BottomNavigation/BottomNavigation';
+import { useNavigate } from 'react-router-dom';
+import { useLoggedIn } from 'src/contexts/LoggedInContext';
+import NoData from 'src/components/common/Error/NoData';
+import ChatRoomListSkeleton from 'src/components/common/Loading/Skeleton/ChatRoomListSkeleton';
+
+function ChatRoomList() {
+  const { isLoggedIn } = useLoggedIn();
+  const { data: chatRoomList, isLoading } = useChatRooms({
+    enabled: isLoggedIn,
+    suspense: true,
+  });
+  const navigate = useNavigate();
+
+  const hasUnreadMessage = (senderId: number, partnerId: number, messageCount: number): boolean =>
+    !!(senderId === partnerId && messageCount);
+
+  const onClickChatRoom = (id: string) => {
+    navigate(`/chat/${id}`);
+  };
+
+  return (
+    <>
+      {isLoading ? (
+        <ChatRoomListSkeleton />
+      ) : chatRoomList?.data.chatRooms.length ? (
+        <Container>
+          {chatRoomList?.data.chatRooms.map(({ id, partner, unreadCount, product, messages }) => {
+            const lastMessage = messages[0];
+            return (
+              <ChatItem key={id} onClick={() => onClickChatRoom(id)}>
+                <UserAndContentWrapper>
+                  <User>{partner.nickname}</User>
+                  <Content>{lastMessage.content}</Content>
+                </UserAndContentWrapper>
+                <TimeAndThumbnailAndUnreadWrapper>
+                  <TimeAndUnreadWrapper>
+                    <Time>{timeForToday(lastMessage.createdAt)}</Time>
+                    {hasUnreadMessage(lastMessage.senderId, partner.id, unreadCount || 0) && (
+                      <Unread>{unreadCount}</Unread>
+                    )}
+                  </TimeAndUnreadWrapper>
+                  <Image src={product.thumbnail.url} box="sm" />
+                </TimeAndThumbnailAndUnreadWrapper>
+              </ChatItem>
+            );
+          })}
+        </Container>
+      ) : (
+        <NoData message="채팅이 없습니다." iconName="iconSpeechDoubleBubble" />
+      )}
+    </>
+  );
+}
+
+export default withAuth(ChatRoomList);
+
+const Container = styled.div`
+  height: calc(100vh - 130px);
+  animation: ${({ theme }) => theme.animation.fadeIn} 0.3s ease-in;
+`;
+
+const ChatItem = styled.div`
+  height: 72px;
+
+  margin: 16px;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  border-bottom: 1px solid ${({ theme }) => theme.color.grey300};
+`;
+
+const UserAndContentWrapper = styled.div`
+  max-width: 60%;
+`;
+
+const User = styled.p`
+  ${({ theme }) => theme.fonts.linkSmall}
+`;
+const Content = styled.p`
+  ${({ theme }) => theme.fonts.textSmall};
+  color: ${({ theme }) => theme.color.grey100};
+
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`;
+const TimeAndThumbnailAndUnreadWrapper = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+`;
+
+const Time = styled.p`
+  ${({ theme }) => theme.fonts.textSmall};
+  color: ${({ theme }) => theme.color.grey100};
+`;
+
+const Unread = styled.p`
+  width: 20px;
+  height: 20px;
+
+  border-radius: 10px;
+
+  background-color: ${({ theme }) => theme.color.primary200};
+  color: ${({ theme }) => theme.color.white};
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  ${({ theme }) => theme.fonts.textXSmall}
+`;
+
+const TimeAndUnreadWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+
+  height: 44px;
+`;

--- a/frontend/src/components/Chatting/ChatRoomList.tsx
+++ b/frontend/src/components/Chatting/ChatRoomList.tsx
@@ -1,18 +1,18 @@
-import Header from 'src/components/common/Header/Header';
-import Image from 'src/components/common/Image/Image';
-import withAuth from 'src/hocs/withAuth';
-import { useChatRooms } from 'src/queries/chatRoom';
 import styled from 'styled-components';
-import timeForToday from 'src/utils/ago';
-import BottomNavigation from 'src/components/common/BottomNavigation/BottomNavigation';
+
+import withAuth from 'src/hocs/withAuth';
+
+import { useChatRooms } from 'src/queries/chatRoom';
 import { useNavigate } from 'react-router-dom';
 import { useLoggedIn } from 'src/contexts/LoggedInContext';
+import timeForToday from 'src/utils/ago';
+
+import Image from 'src/components/common/Image/Image';
 import NoData from 'src/components/common/Error/NoData';
-import ChatRoomListSkeleton from 'src/components/common/Loading/Skeleton/ChatRoomListSkeleton';
 
 function ChatRoomList() {
   const { isLoggedIn } = useLoggedIn();
-  const { data: chatRoomList, isLoading } = useChatRooms({
+  const { data: chatRoomList } = useChatRooms({
     enabled: isLoggedIn,
     suspense: true,
   });
@@ -25,37 +25,30 @@ function ChatRoomList() {
     navigate(`/chat/${id}`);
   };
 
+  if (!chatRoomList || chatRoomList.data.chatRooms.length === 0)
+    return <NoData message="채팅이 없습니다." iconName="iconSpeechDoubleBubble" />;
+
   return (
-    <>
-      {isLoading ? (
-        <ChatRoomListSkeleton />
-      ) : chatRoomList?.data.chatRooms.length ? (
-        <Container>
-          {chatRoomList?.data.chatRooms.map(({ id, partner, unreadCount, product, messages }) => {
-            const lastMessage = messages[0];
-            return (
-              <ChatItem key={id} onClick={() => onClickChatRoom(id)}>
-                <UserAndContentWrapper>
-                  <User>{partner.nickname}</User>
-                  <Content>{lastMessage.content}</Content>
-                </UserAndContentWrapper>
-                <TimeAndThumbnailAndUnreadWrapper>
-                  <TimeAndUnreadWrapper>
-                    <Time>{timeForToday(lastMessage.createdAt)}</Time>
-                    {hasUnreadMessage(lastMessage.senderId, partner.id, unreadCount || 0) && (
-                      <Unread>{unreadCount}</Unread>
-                    )}
-                  </TimeAndUnreadWrapper>
-                  <Image src={product.thumbnail.url} box="sm" />
-                </TimeAndThumbnailAndUnreadWrapper>
-              </ChatItem>
-            );
-          })}
-        </Container>
-      ) : (
-        <NoData message="채팅이 없습니다." iconName="iconSpeechDoubleBubble" />
-      )}
-    </>
+    <Container>
+      {chatRoomList.data.chatRooms.map(({ id, partner, unreadCount, product, messages }) => {
+        const lastMessage = messages[0];
+        return (
+          <ChatItem key={id} onClick={() => onClickChatRoom(id)}>
+            <UserAndContentWrapper>
+              <User>{partner.nickname}</User>
+              <Content>{lastMessage.content}</Content>
+            </UserAndContentWrapper>
+            <TimeAndThumbnailAndUnreadWrapper>
+              <TimeAndUnreadWrapper>
+                <Time>{timeForToday(lastMessage.createdAt)}</Time>
+                {hasUnreadMessage(lastMessage.senderId, partner.id, unreadCount || 0) && <Unread>{unreadCount}</Unread>}
+              </TimeAndUnreadWrapper>
+              <Image src={product.thumbnail.url} box="sm" />
+            </TimeAndThumbnailAndUnreadWrapper>
+          </ChatItem>
+        );
+      })}
+    </Container>
   );
 }
 

--- a/frontend/src/components/common/Loading/Skeleton/ChatRommDetailSkeleton.tsx
+++ b/frontend/src/components/common/Loading/Skeleton/ChatRommDetailSkeleton.tsx
@@ -1,9 +1,13 @@
-import ChatInput from 'src/components/ChatRoom/ChatInput';
 import styled from 'styled-components';
+import { useDelay } from 'src/hooks/useDelay';
 import Header from '../../Header/Header';
 import Icon from '../../Icon/Icon';
 
 function ChatRoomDetailSkeleton() {
+  const isDelay = useDelay();
+
+  if (isDelay) return null;
+
   const CHAT_COUNT = 15;
   const getRandomWidth = () => Math.ceil(30 + Math.random() * 50);
   const getRandomBoolean = () => Math.random() * 10 > 5;

--- a/frontend/src/components/common/Loading/Skeleton/ChatRoomListSkeleton.tsx
+++ b/frontend/src/components/common/Loading/Skeleton/ChatRoomListSkeleton.tsx
@@ -1,6 +1,11 @@
 import styled from 'styled-components';
+import { useDelay } from 'src/hooks/useDelay';
 
 function ChatRoomListSkeleton() {
+  const isDelay = useDelay();
+
+  if (isDelay) return null;
+
   const CHAT_COUNT = 10;
   const getRandomWidth = () => `${Math.ceil(30 + Math.random() * 50)}%`;
   return (

--- a/frontend/src/hooks/useDelay.ts
+++ b/frontend/src/hooks/useDelay.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react';
+
+export function useDelay() {
+  const [isDelay, setIsDelay] = useState(true);
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setIsDelay(false);
+    }, 300);
+    return () => clearTimeout(timeoutId);
+  }, []);
+
+  return isDelay;
+}

--- a/frontend/src/routers/ChatRoom.tsx
+++ b/frontend/src/routers/ChatRoom.tsx
@@ -1,133 +1,17 @@
-import Header from 'src/components/common/Header/Header';
-import Icon from 'src/components/common/Icon/Icon';
-import Image from 'src/components/common/Image/Image';
 import withAuth from 'src/hocs/withAuth';
-import { useChatRooms } from 'src/queries/chatRoom';
-import styled from 'styled-components';
-import timeForToday from 'src/utils/ago';
+
+import Header from 'src/components/common/Header/Header';
+import ChatRoomList from 'src/components/Chatting/ChatRoomList';
 import BottomNavigation from 'src/components/common/BottomNavigation/BottomNavigation';
-import { useNavigate } from 'react-router-dom';
-import { useLoggedIn } from 'src/contexts/LoggedInContext';
-import NoData from 'src/components/common/Error/NoData';
-import ChatRoomListSkeleton from 'src/components/common/Loading/Skeleton/ChatRoomListSkeleton';
 
 function ChatRoom() {
-  const { isLoggedIn } = useLoggedIn();
-  const { data: chatRoomList, isLoading } = useChatRooms({
-    enabled: isLoggedIn,
-  });
-  const navigate = useNavigate();
-
-  const hasUnreadMessage = (senderId: number, partnerId: number, messageCount: number): boolean =>
-    !!(senderId === partnerId && messageCount);
-
-  const onClickChatRoom = (id: string) => {
-    navigate(`/chat/${id}`);
-  };
-
   return (
     <>
       <Header headerTheme="offWhite" center={<p>채팅</p>} />
-      {isLoading ? (
-        <ChatRoomListSkeleton />
-      ) : chatRoomList?.data.chatRooms.length ? (
-        <Container>
-          {chatRoomList?.data.chatRooms.map(({ id, partner, unreadCount, product, messages }) => {
-            const lastMessage = messages[0];
-            return (
-              <ChatItem key={id} onClick={() => onClickChatRoom(id)}>
-                <UserAndContentWrapper>
-                  <User>{partner.nickname}</User>
-                  <Content>{lastMessage.content}</Content>
-                </UserAndContentWrapper>
-                <TimeAndThumbnailAndUnreadWrapper>
-                  <TimeAndUnreadWrapper>
-                    <Time>{timeForToday(lastMessage.createdAt)}</Time>
-                    {hasUnreadMessage(lastMessage.senderId, partner.id, unreadCount || 0) && (
-                      <Unread>{unreadCount}</Unread>
-                    )}
-                  </TimeAndUnreadWrapper>
-                  <Image src={product.thumbnail.url} box="sm" />
-                </TimeAndThumbnailAndUnreadWrapper>
-              </ChatItem>
-            );
-          })}
-        </Container>
-      ) : (
-        <NoData message="채팅이 없습니다." iconName="iconSpeechDoubleBubble" />
-      )}
-
+      <ChatRoomList />
       <BottomNavigation />
     </>
   );
 }
 
 export default withAuth(ChatRoom);
-
-const Container = styled.div`
-  height: calc(100vh - 130px);
-  animation: ${({ theme }) => theme.animation.fadeIn} 0.3s ease-in;
-`;
-
-const ChatItem = styled.div`
-  height: 72px;
-
-  margin: 16px;
-
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-
-  border-bottom: 1px solid ${({ theme }) => theme.color.grey300};
-`;
-
-const UserAndContentWrapper = styled.div`
-  max-width: 60%;
-`;
-
-const User = styled.p`
-  ${({ theme }) => theme.fonts.linkSmall}
-`;
-const Content = styled.p`
-  ${({ theme }) => theme.fonts.textSmall};
-  color: ${({ theme }) => theme.color.grey100};
-
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-`;
-const TimeAndThumbnailAndUnreadWrapper = styled.div`
-  display: flex;
-  align-items: flex-start;
-  gap: 16px;
-`;
-
-const Time = styled.p`
-  ${({ theme }) => theme.fonts.textSmall};
-  color: ${({ theme }) => theme.color.grey100};
-`;
-
-const Unread = styled.p`
-  width: 20px;
-  height: 20px;
-
-  border-radius: 10px;
-
-  background-color: ${({ theme }) => theme.color.primary200};
-  color: ${({ theme }) => theme.color.white};
-
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  ${({ theme }) => theme.fonts.textXSmall}
-`;
-
-const TimeAndUnreadWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 4px;
-
-  height: 44px;
-`;

--- a/frontend/src/routers/ChatRoom.tsx
+++ b/frontend/src/routers/ChatRoom.tsx
@@ -1,14 +1,20 @@
+import { Suspense } from 'react';
+
 import withAuth from 'src/hocs/withAuth';
 
 import Header from 'src/components/common/Header/Header';
 import ChatRoomList from 'src/components/Chatting/ChatRoomList';
 import BottomNavigation from 'src/components/common/BottomNavigation/BottomNavigation';
 
+import ChatRoomListSkeleton from 'src/components/common/Loading/Skeleton/ChatRoomListSkeleton';
+
 function ChatRoom() {
   return (
     <>
       <Header headerTheme="offWhite" center={<p>채팅</p>} />
-      <ChatRoomList />
+      <Suspense fallback={<ChatRoomListSkeleton />}>
+        <ChatRoomList />
+      </Suspense>
       <BottomNavigation />
     </>
   );


### PR DESCRIPTION
## 📰 **Summary**
스켈레톤 UI 가 짧은 시간동안 번쩍이는 부분이 사용자에게 불편함을 느끼게 한다고 생각하여 수정했습니다.

## 🔎 **Checklist**

- [ ] 비동기 요청에 대한 로딩 상태를 선언적으로 다루기 위해 suspense를 적용했습니다.
- [ ] route의 element 에 suspense 를 넣어주고 싶지 않았고, 채팅 목록을 렌더링하는 컴포넌트가 따로 필요하다고 생각하여
채팅 목록 컴포넌트를 따로 분리했습니다.
- [ ] 300ms 의 지연시간을 줘서 0 ~ 300ms 까지는 아무것도 보여주지 않고, 그 이후에는 스켈레톤 UI 를 보여주도록 했습니다.
(300ms 인 이유는 응답시간지표 자료를 참고했습니다. [참고](https://tech.kakaopay.com/post/skeleton-ui-idea/#firebase-performance-monitoring) )

## 🍟 **Additional context**
<image src="https://user-images.githubusercontent.com/52899349/194834366-35f056a3-e01b-4f67-9bf7-ec24618d5fd8.gif" width=200 /> <image src="https://user-images.githubusercontent.com/52899349/194834374-43636361-329b-44e1-9f44-aa48d8bc6524.gif" width=200 />


## ⏰ **Estimated time**
3h
